### PR TITLE
Extract and persist name from Apple Sign In credentials

### DIFF
--- a/__tests__/components/auth/AppleSignInButton.test.tsx
+++ b/__tests__/components/auth/AppleSignInButton.test.tsx
@@ -730,7 +730,7 @@ describe('AppleSignInButton', () => {
       });
     });
 
-    it('uses empty string fallback when getUser returns null user', async () => {
+    it('logs warning and skips profile update when getUser returns null user', async () => {
       mockSignInAsync.mockResolvedValueOnce({
         identityToken: 'mock-identity-token',
         fullName: {
@@ -747,12 +747,18 @@ describe('AppleSignInButton', () => {
       fireEvent.press(screen.getByTestId('apple-sign-in-button'));
 
       await waitFor(() => {
-        // Should use empty string as fallback when user is null
-        expect(mockProfileUpdateEq).toHaveBeenCalledWith('id', '');
+        // Should log warning about missing user ID
+        expect(mockLoggerWarn).toHaveBeenCalledWith(
+          'Cannot update profile: user ID not available after sign-in',
+          { category: 'auth' }
+        );
       });
+
+      // Should NOT attempt to update the profile
+      expect(mockProfileUpdate).not.toHaveBeenCalled();
     });
 
-    it('uses empty string fallback when getUser returns undefined user', async () => {
+    it('logs warning and skips profile update when getUser returns undefined user', async () => {
       mockSignInAsync.mockResolvedValueOnce({
         identityToken: 'mock-identity-token',
         fullName: {
@@ -769,9 +775,15 @@ describe('AppleSignInButton', () => {
       fireEvent.press(screen.getByTestId('apple-sign-in-button'));
 
       await waitFor(() => {
-        // Should use empty string as fallback when user is undefined
-        expect(mockProfileUpdateEq).toHaveBeenCalledWith('id', '');
+        // Should log warning about missing user ID
+        expect(mockLoggerWarn).toHaveBeenCalledWith(
+          'Cannot update profile: user ID not available after sign-in',
+          { category: 'auth' }
+        );
       });
+
+      // Should NOT attempt to update the profile
+      expect(mockProfileUpdate).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
This pull request significantly enhances the handling and testing of user name extraction and persistence during Apple Sign In, ensuring that the user's name is correctly captured and stored both in user metadata and the profile database, even in the presence of known race conditions. It also adds robust test coverage for various edge cases related to name data and improves logging for both success and failure scenarios.

**Apple Sign In name extraction and persistence:**

* The `AppleSignInButton` component now detects and persists the user's name (given and family name) on the first Apple sign-in by updating both `user_metadata` and the `profiles` table, working around a race condition with profile creation. This includes logic for handling missing name parts and calculating the last initial.

**Testing improvements for Apple Sign In:**

* Extensive new tests in `AppleSignInButton.test.tsx` cover all edge cases for name extraction: full name present, only given or family name, no name, and error handling for update failures. Tests verify that updates and logging occur (or not) as expected in each scenario.
* Additional mocks for `supabase.auth.updateUser`, `supabase.auth.getUser`, and profile updates are introduced to support the new logic and tests.
* Default mock implementations are set in `resetMocks` to ensure consistent test setup for new auth and profile update flows.

**Logging enhancements:**

* The logger mock now includes a `warn` method, and the code logs warnings if updating user metadata or the profile fails, while still allowing sign-in to proceed. [[1]](diffhunk://#diff-b3edc37f669abfe02d54e5ee2a5a6afb378bdcb4eebd34a5832c69259a18a21bR98-R103) [[2]](diffhunk://#diff-b6411d57d570faac8d3f0880f58a176b88fcf66ff4650cb2c238a1039aafff96R72-R137)

These changes ensure that user name data from Apple is reliably captured and that the codebase is well-tested for various real-world scenarios.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Capture Apple-provided name on first sign-in; update Supabase user_metadata and profiles, add logging, and comprehensive tests for edge cases.
> 
> - **Auth (AppleSignInButton)**:
>   - Persist Apple name on first sign-in: compute `full_name`, `given_name`, `family_name`, and `last_initial`.
>   - Update `supabase.auth.updateUser` and `profiles` (via `from('profiles').update().eq('id', userId)`), using `supabase.auth.getUser` for `userId`.
>   - Add warnings when metadata/profile updates fail; info log on success; handle missing name parts and cancellation.
> - **Tests**:
>   - Add mocks for `updateUser`, `getUser`, profile updates, and `logger.warn` with default behaviors.
>   - New cases covering full/missing name parts, no name (subsequent sign-ins), update failures, missing `userId`, and success logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29fbb1fa1423603c50bca970d42191dc2d7f9dd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->